### PR TITLE
[bugfix] Re-aligned the dot within the ui-tag  

### DIFF
--- a/modules/ui.styl
+++ b/modules/ui.styl
@@ -75,6 +75,7 @@
     height: 1cap
     display: inline-block
     margin-right: .25rem
+    margin-bottom: 2px
 
 .ui-av-tag
   @extend .font-size-7


### PR DESCRIPTION
Added a mb to ui tag:before to align the dot to the centre. 