### PR TITLE
Upstream: container vars, ui-embed-container, nested grid/box rename, border greys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `$container-*` Stylus variables (`$container-xxl`…`$container-smax`) for use in `@media`/`calc`, mirroring the `--container-*` custom properties
+- `$container-*` Stylus variables (`$container-xxl`…`$container-smax`) for use in `calc()` (and `@media` width queries for the length-valued ones; note `$container-s` is `98%`), mirroring the `--container-*` custom properties
 - `.ui-button--gray` button modifier
 - `.ui-border--gray-mid` border colour modifier
 - `.ui-rounded-box--nested` (4px) modifier for nested colour-blocked boxes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- `.ui-rounded-image` → use `.ui-rounded-box`; removed next release
-- `.ui-rounded-box--large` → use `.ui-rounded-box--nested`; removed next release
-- `.grid--nested` / `.grid--nested-tight` → use `.grid-row--nested(-tight)`; removed next release
-- `.u-video-embed-container` / `.ui-responsive-video-container` → use `.ui-embed-container`; removed next release
+- `.ui-rounded-image` → use `.ui-rounded-box`; removed in v0.15.0
+- `.ui-rounded-box--large` → use `.ui-rounded-box--nested`; removed in v0.15.0
+- `.grid--nested` / `.grid--nested-tight` → use `.grid-row--nested(-tight)`; removed in v0.15.0
+- `.u-video-embed-container` / `.ui-responsive-video-container` → use `.ui-embed-container`; removed in v0.15.0
 
 ## [0.13.0] - 2026-02-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `$container-*` Stylus variables (`$container-xxl`…`$container-smax`) for use in `@media`/`calc`, mirroring the `--container-*` custom properties
+- `.ui-button--gray` button modifier
+- `.ui-border--gray-mid` border colour modifier
+- `.ui-rounded-box--nested` (4px) modifier for nested colour-blocked boxes
+- `.grid-row--nested` / `.grid-row--nested-tight` — canonical names for nested-grid negative margins
+- `.ui-embed-container` responsive aspect-ratio embed container (default 16:9) with `--4-3` / `--1-1` ratio modifiers
+
+### Changed
+
+- `.ui-tag` dot indicator sized in `em` (`0.7em`) instead of `1cap` for cross-browser consistency
+- `.ui-border`, `.ui-border-top`, `.ui-border-bottom`, `.ui-border-left` now use `--color-gray-light` (new grey) instead of `--color-gray-light-old`
+
 ### Fixed
 
 - Corrected xxl container size variable
+- `.text-overflow-ellipsis` now uses valid `white-space` + `overflow` + `text-overflow` (was invalid `overflow: ellipsis`)
+
+### Deprecated
+
+- `.ui-rounded-image` → use `.ui-rounded-box`; removed next release
+- `.ui-rounded-box--large` → use `.ui-rounded-box--nested`; removed next release
+- `.grid--nested` / `.grid--nested-tight` → use `.grid-row--nested(-tight)`; removed next release
+- `.u-video-embed-container` / `.ui-responsive-video-container` → use `.ui-embed-container`; removed next release
 
 ## [0.13.0] - 2026-02-09
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,68 @@
+# Code conventions — nm-stylus-library
+
+Lightweight conventions for this design-system library. Stylus strips `//`
+comments at compile time, so these cost nothing in shipped CSS.
+
+## Doc headers
+
+Each module, mixin, and component block gets a **one-line purpose comment**
+directly above it (already the norm across `modules/*`). Keep it to one line.
+
+```stylus
+// Responsive aspect-ratio container for iframes / embeds (video, maps, etc.).
+.ui-embed-container
+  ...
+```
+
+## Deprecation comments
+
+Mark any deprecated class / mixin / variable with a single-line comment
+**directly above** the symbol:
+
+```stylus
+// @deprecated since vX.Y.Z → use <replacement>. Removed: vA.B.0
+.old-thing
+  ...
+```
+
+- `since` — the version that introduced the deprecation.
+- `Removed:` — the version it will be deleted in. Default to the **next minor**
+  (one-cycle deprecation window).
+- When the comment can't sit directly above a single symbol (e.g. two selectors
+  share one declaration block), name the deprecated symbol explicitly:
+
+```stylus
+// @deprecated since vX.Y.Z: .old-name → use .new-name. Removed: vA.B.0
+.new-name, .old-name
+  ...
+```
+
+### Why this format
+
+It is **greppable**, which lets the upstream/version-bump workflow find work
+mechanically:
+
+```bash
+grep -rn "@deprecated since"        # every active deprecation
+grep -rn "Removed: v0.15.0"         # everything due for deletion in 0.15.0
+```
+
+When cutting a release, grep `Removed: v<this-version>` and delete those symbols
++ their comments.
+
+## Locally-scoped CSS variables for modifiers
+
+When a base utility has colour/size variants, drive the varying property through
+a **locally-scoped custom property** that the base sets as a default and
+modifiers override. This makes a modifier work uniformly regardless of which
+base helper it's paired with.
+
+```stylus
+.ui-rounded-box
+  --ui-border-radius: var(--corner-radius)   // default
+  border-radius: var(--ui-border-radius)
+  &--nested
+    --ui-border-radius: var(--corner-radius-large)   // override
+
+// borders follow the same pattern with --ui-border-color
+```

--- a/functions/grid-function-new.styl
+++ b/functions/grid-function-new.styl
@@ -60,12 +60,14 @@ grid-maker($size = false, $cols = 24)
       padding-right: calc(var(--grid-gutter) / 4);
     }
 
-    .grid--nested {
+    // .grid--nested @deprecated since v0.14.0 → .grid-row--nested. Removed next release.
+    .grid-row--nested, .grid--nested {
       margin-left: calc(var(--grid-gutter) / 2 * -1);
       margin-right: calc(var(--grid-gutter) / 2 * -1);
     }
 
-    .grid--nested-tight {
+    // .grid--nested-tight @deprecated since v0.14.0 → .grid-row--nested-tight. Removed next release.
+    .grid-row--nested-tight, .grid--nested-tight {
       margin-left: calc(var(--grid-gutter) / 4 * -1);
       margin-right: calc(var(--grid-gutter) / 4 * -1);
     }

--- a/functions/grid-function-new.styl
+++ b/functions/grid-function-new.styl
@@ -60,13 +60,13 @@ grid-maker($size = false, $cols = 24)
       padding-right: calc(var(--grid-gutter) / 4);
     }
 
-    // .grid--nested @deprecated since v0.14.0 → .grid-row--nested. Removed next release.
+    // @deprecated since v0.14.0: .grid--nested → use .grid-row--nested. Removed: v0.15.0
     .grid-row--nested, .grid--nested {
       margin-left: calc(var(--grid-gutter) / 2 * -1);
       margin-right: calc(var(--grid-gutter) / 2 * -1);
     }
 
-    // .grid--nested-tight @deprecated since v0.14.0 → .grid-row--nested-tight. Removed next release.
+    // @deprecated since v0.14.0: .grid--nested-tight → use .grid-row--nested-tight. Removed: v0.15.0
     .grid-row--nested-tight, .grid--nested-tight {
       margin-left: calc(var(--grid-gutter) / 4 * -1);
       margin-right: calc(var(--grid-gutter) / 4 * -1);

--- a/modules/typography.styl
+++ b/modules/typography.styl
@@ -122,7 +122,9 @@ font-size-maker()
   line-height: 1.2
 
 .text-overflow-ellipsis
-  overflow: ellipsis
+  white-space: nowrap
+  overflow: hidden
+  text-overflow: ellipsis
 
 .text-align-left
   text-align: left

--- a/modules/ui.styl
+++ b/modules/ui.styl
@@ -347,6 +347,7 @@ hr
 // Rounded Elements
 // -------------
 
+// @deprecated since v0.14.0 → use .ui-rounded-box (CSS-identical at default). Removed next release.
 .ui-rounded-image
   --ui-border-radius: var(--corner-radius)
   border-radius: var(--ui-border-radius)
@@ -356,6 +357,9 @@ hr
 .ui-rounded-box
   --ui-border-radius: var(--corner-radius)
   border-radius: var(--ui-border-radius)
+  &--nested
+    --ui-border-radius: var(--corner-radius-large)
+  // @deprecated since v0.14.0 → use --nested. Removed next release.
   &--large
     --ui-border-radius: var(--corner-radius-large)
   &--top

--- a/modules/ui.styl
+++ b/modules/ui.styl
@@ -262,6 +262,7 @@ formElementBase() // This could be a class that is extended rather than a mixin
 
   &--gray
     background-color: var(--color-gray-mid)
+    border-color: var(--color-gray-mid)
     color: var(--color-black-soft)
     &:hover
       border-color: var(--color-gray-mid)
@@ -319,8 +320,23 @@ hr
   border: 0
   height: 1px
   margin: 0
-  background-color: var(--color-gray-light-old)
+  background-color: var(--color-gray-light)
 
+// ===========================================================================
+// FIXME(greys): UI grey tokens need a full audit before further migration.
+// The border utilities below + `hr` now use --color-gray-light (new grey),
+// but these still reference the legacy --color-gray-light-old and were NOT
+// migrated this cycle because it's unconfirmed which grey is correct — the
+// tokens drifted between actual usage and the latest build:
+//   modules/ui.styl:        ~line 61 (background), ~120 & ~138 (input borders),
+//                           formElementBase --border-gray & :disabled,
+//                           .ui-button--disabled
+//   modules/backgrounds.styl: ~line 25 (background)
+// Also: variables.json has duplicate greys (grayMid == grayMidNew == #D4D4D4).
+// ACTION: audit every --color-gray-light-old / grayMidNew usage against the
+// design-system source colours, decide the correct token per element, then
+// migrate + remove the legacy tokens in a dedicated follow-up.
+// ===========================================================================
 .ui-border
   border: 1px solid var(--color-gray-light)
 

--- a/modules/ui.styl
+++ b/modules/ui.styl
@@ -265,6 +265,7 @@ formElementBase() // This could be a class that is extended rather than a mixin
     border-color: var(--color-gray-mid)
     color: var(--color-black-soft)
     &:hover
+      background-color: transparent
       border-color: var(--color-gray-mid)
       color: var(--color-black-soft)
 
@@ -338,22 +339,28 @@ hr
 // migrate + remove the legacy tokens in a dedicated follow-up.
 // ===========================================================================
 .ui-border
-  border: 1px solid var(--color-gray-light)
+  --ui-border-color: var(--color-gray-light)
+  border: 1px solid var(--ui-border-color)
 
 .ui-border-bottom
-  border-bottom: 1px solid var(--color-gray-light)
+  --ui-border-color: var(--color-gray-light)
+  border-bottom: 1px solid var(--ui-border-color)
 
 .ui-border-top
-  border-top: 1px solid var(--color-gray-light)
+  --ui-border-color: var(--color-gray-light)
+  border-top: 1px solid var(--ui-border-color)
 
 .ui-border-left
-  border-left: 1px solid var(--color-gray-light)
+  --ui-border-color: var(--color-gray-light)
+  border-left: 1px solid var(--ui-border-color)
 
+// Colour modifiers override --ui-border-color, so they apply to any single-side
+// or all-side border helper above. Pair with a base helper (which sets width).
 .ui-border--black
-  border-color: var(--color-black-soft)
+  --ui-border-color: var(--color-black-soft)
 
 .ui-border--gray-mid
-  border-color: var(--color-gray-mid)
+  --ui-border-color: var(--color-gray-mid)
 
 @media screen and (max-width: $breakpoint-m)
   .ui-border--not-m
@@ -366,7 +373,7 @@ hr
 // Rounded Elements
 // -------------
 
-// @deprecated since v0.14.0 → use .ui-rounded-box (CSS-identical at default). Removed next release.
+// @deprecated since v0.14.0 → use .ui-rounded-box (CSS-identical at default). Removed: v0.15.0
 .ui-rounded-image
   --ui-border-radius: var(--corner-radius)
   border-radius: var(--ui-border-radius)
@@ -378,7 +385,7 @@ hr
   border-radius: var(--ui-border-radius)
   &--nested
     --ui-border-radius: var(--corner-radius-large)
-  // @deprecated since v0.14.0 → use --nested. Removed next release.
+  // @deprecated since v0.14.0 → use --nested. Removed: v0.15.0
   &--large
     --ui-border-radius: var(--corner-radius-large)
   &--top
@@ -539,7 +546,7 @@ hr
     display: inline-block
     margin-right: 1rem
 
-// @deprecated since v0.14.0 → use .ui-embed-container. Removed next release. (Un-nested from .ui-inline-list, where it was previously scoped by accident.)
+// @deprecated since v0.14.0 → use .ui-embed-container. Removed: v0.15.0 (Un-nested from .ui-inline-list, where it was previously scoped by accident.)
 .ui-responsive-video-container
   position: relative
   padding-bottom: 56.25%

--- a/modules/ui.styl
+++ b/modules/ui.styl
@@ -260,6 +260,13 @@ formElementBase() // This could be a class that is extended rather than a mixin
     &:hover
       color: var(--color-green)
 
+  &--gray
+    background-color: var(--color-gray-mid)
+    color: var(--color-black-soft)
+    &:hover
+      border-color: var(--color-gray-mid)
+      color: var(--color-black-soft)
+
   &--disabled
     background-color: var(--color-gray-light-old)
     color: var(--color-black-soft)

--- a/modules/ui.styl
+++ b/modules/ui.styl
@@ -525,6 +525,7 @@ hr
 
   // Video Embeds
 
+  // @deprecated since v0.14.0 → use .ui-embed-container (also fixes this rule's accidental nesting under .ui-inline-list). Removed next release.
   .ui-responsive-video-container
     position: relative
     padding-bottom: 56.25%
@@ -538,3 +539,23 @@ hr
       width: 100%
       height: 100%
       clip-path: inset(1px 1px)
+
+// Embeds
+// -------------
+
+// Responsive aspect-ratio container for iframes / embeds (video, maps, etc.).
+// Default 16:9; use ratio modifiers for other ratios.
+.ui-embed-container
+  width: 100%
+  aspect-ratio: 16 / 9
+  overflow: hidden
+  iframe, object, embed, video
+    width: 100%
+    height: 100%
+    border: 0
+    display: block
+    clip-path: inset(1px 1px)
+  &--4-3
+    aspect-ratio: 4 / 3
+  &--1-1
+    aspect-ratio: 1 / 1

--- a/modules/ui.styl
+++ b/modules/ui.styl
@@ -539,22 +539,20 @@ hr
     display: inline-block
     margin-right: 1rem
 
-  // Video Embeds
-
-  // @deprecated since v0.14.0 → use .ui-embed-container (also fixes this rule's accidental nesting under .ui-inline-list). Removed next release.
-  .ui-responsive-video-container
-    position: relative
-    padding-bottom: 56.25%
-    height: 0
-    overflow: hidden
-    max-width: 100%
-    iframe, object, embed
-      position: absolute
-      top: 0
-      left: 0
-      width: 100%
-      height: 100%
-      clip-path: inset(1px 1px)
+// @deprecated since v0.14.0 → use .ui-embed-container. Removed next release. (Un-nested from .ui-inline-list, where it was previously scoped by accident.)
+.ui-responsive-video-container
+  position: relative
+  padding-bottom: 56.25%
+  height: 0
+  overflow: hidden
+  max-width: 100%
+  iframe, object, embed
+    position: absolute
+    top: 0
+    left: 0
+    width: 100%
+    height: 100%
+    clip-path: inset(1px 1px)
 
 // Embeds
 // -------------

--- a/modules/ui.styl
+++ b/modules/ui.styl
@@ -322,19 +322,22 @@ hr
   background-color: var(--color-gray-light-old)
 
 .ui-border
-  border: 1px solid var(--color-gray-light-old)
+  border: 1px solid var(--color-gray-light)
 
 .ui-border-bottom
-  border-bottom: 1px solid var(--color-gray-light-old)
+  border-bottom: 1px solid var(--color-gray-light)
 
 .ui-border-top
-  border-top: 1px solid var(--color-gray-light-old)
+  border-top: 1px solid var(--color-gray-light)
 
 .ui-border-left
-  border-left: 1px solid var(--color-gray-light-old)
+  border-left: 1px solid var(--color-gray-light)
 
 .ui-border--black
   border-color: var(--color-black-soft)
+
+.ui-border--gray-mid
+  border-color: var(--color-gray-mid)
 
 @media screen and (max-width: $breakpoint-m)
   .ui-border--not-m

--- a/modules/ui.styl
+++ b/modules/ui.styl
@@ -126,8 +126,8 @@
     content: ''
     background-color: var(--color-black-soft)
     border-radius: 50%
-    width 1cap
-    height: 1cap
+    width: 0.7em
+    height: 0.7em
     display: inline-block
     margin-right: .25rem
 

--- a/scripts/build-variables.js
+++ b/scripts/build-variables.js
@@ -42,6 +42,15 @@ function generateStylusContent(variables) {
   });
   content += '\n';
 
+  // Container width Stylus variables (mirror --container-* custom props; usable in @media / calc)
+  content += '// Container widths\n';
+  Object.entries(variables.layout)
+    .filter(([key]) => key.startsWith('container'))
+    .forEach(([key, value]) => {
+      content += `$${camelToKebab(key)} = ${value}\n`;
+    });
+  content += '\n';
+
   // Then add CSS custom properties in html block
   content += 'html\n';
   

--- a/scripts/build-variables.js
+++ b/scripts/build-variables.js
@@ -42,7 +42,8 @@ function generateStylusContent(variables) {
   });
   content += '\n';
 
-  // Container width Stylus variables (mirror --container-* custom props; usable in @media / calc)
+  // Container width Stylus variables (mirror --container-* custom props). Usable in calc(),
+  // and in @media width queries where the value is a length — note $container-s is a percentage (98%).
   content += '// Container widths\n';
   Object.entries(variables.layout)
     .filter(([key]) => key.startsWith('container'))

--- a/scripts/validate-variables.js
+++ b/scripts/validate-variables.js
@@ -47,9 +47,17 @@ function validateSynchronization() {
     }
     console.log('Stylus breakpoint variables are synchronized');
 
+    // Helper function: Convert camelCase to kebab-case (matches build-variables.js)
+    function camelToKebab(str) {
+      return str
+        .replace(/([a-z])([A-Z])/g, '$1-$2')  // lowercase letter followed by uppercase letter
+        .replace(/([a-zA-Z])([0-9])/g, '$1-$2')  // letter followed by digit
+        .toLowerCase();
+    }
+
     // Test: Check if Stylus file contains expected color CSS custom properties
     for (const [key, value] of Object.entries(variablesJson.colors)) {
-      const cssVar = key.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+      const cssVar = camelToKebab(key);
       const expectedLine = `--color-${cssVar}: ${value}`;
       if (!stylusContent.includes(expectedLine)) {
         console.error(`Stylus missing color variable: ${expectedLine}`);

--- a/scripts/validate-variables.js
+++ b/scripts/validate-variables.js
@@ -66,6 +66,16 @@ function validateSynchronization() {
     }
     console.log('Stylus color variables are synchronized');
 
+    // Test: Check if Stylus file contains expected container variables
+    for (const [key, value] of Object.entries(variablesJson.layout).filter(([k]) => k.startsWith('container'))) {
+      const expectedLine = `$${camelToKebab(key)} = ${value}`;
+      if (!stylusContent.includes(expectedLine)) {
+        console.error(`Stylus missing container variable: ${expectedLine}`);
+        process.exit(1);
+      }
+    }
+    console.log('Stylus container variables are synchronized');
+
     // Test: Check if JavaScript file can be required/imported
     const jsContent = fs.readFileSync(VARIABLES_JS_PATH, 'utf8');
     

--- a/utility/helpers.styl
+++ b/utility/helpers.styl
@@ -54,7 +54,7 @@
  * Responsive oembed
  */
 
-// @deprecated since v0.14.0 → use .ui-embed-container. Removed next release.
+// @deprecated since v0.14.0 → use .ui-embed-container. Removed: v0.15.0
 .u-video-embed-container
   position: relative
   padding-bottom: 56.25%

--- a/utility/helpers.styl
+++ b/utility/helpers.styl
@@ -54,6 +54,7 @@
  * Responsive oembed
  */
 
+// @deprecated since v0.14.0 → use .ui-embed-container. Removed next release.
 .u-video-embed-container
   position: relative
   padding-bottom: 56.25%

--- a/variables.styl
+++ b/variables.styl
@@ -7,6 +7,14 @@ $breakpoint-xl = 1408px
 // Constants
 $golden-ratio = 1.61803398875
 
+// Container widths
+$container-xxl = 1400px
+$container-xl = 1056px
+$container-l = 888px
+$container-m = 744px
+$container-s = 98%
+$container-smax = 460px
+
 html
   // layout
   --grid-gutter: 1rem


### PR DESCRIPTION
Design system updates targeting the 0.14.0 release.

## Added
- `$container-*` Stylus variables (`$container-xxl`…`$container-smax`) for `@media`/`calc`, mirroring the `--container-*` custom properties
- `.ui-button--gray` button modifier
- `.ui-border--gray-mid` border colour modifier
- `.ui-rounded-box--nested` (4px) modifier for nested colour-blocked boxes
- `.grid-row--nested` / `.grid-row--nested-tight` — canonical names for nested-grid negative margins
- `.ui-embed-container` responsive aspect-ratio embed container (default 16:9) with `--4-3` / `--1-1` modifiers

## Changed
- `.ui-tag` dot sized in `em` (`0.7em`) instead of `1cap` for cross-browser consistency
- Border utils now use `--color-gray-light` (new grey) instead of `--color-gray-light-old`

## Fixed
- Corrected xxl container size variable
- `.text-overflow-ellipsis` now uses valid `white-space` + `overflow` + `text-overflow`

## Deprecated (removed next release)
- `.ui-rounded-image` → `.ui-rounded-box`
- `.ui-rounded-box--large` → `.ui-rounded-box--nested`
- `.grid--nested` / `.grid--nested-tight` → `.grid-row--nested(-tight)`
- `.u-video-embed-container` / `.ui-responsive-video-container` → `.ui-embed-container`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
