### PR TITLE
fix: extend serif font-family to ul/ol in .text-copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Implmentation of corner radius for buttons
 - Spacing unit for letter-spacing in the font size generator
-
-### Fixed
-
 - List items (`ul`, `ol`) inside `.text-copy` now use `--font-family-serif` matching paragraph copy
 
 ## [0.10.0] - 2025-04-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implmentation of corner radius for buttons
 - Spacing unit for letter-spacing in the font size generator
 
+### Fixed
+
+- List items (`ul`, `ol`) inside `.text-copy` now use `--font-family-serif` matching paragraph copy
+
 ## [0.10.0] - 2025-04-16
 
 ### Added

--- a/modules/typography.styl
+++ b/modules/typography.styl
@@ -144,7 +144,7 @@ article
       list-style: decimal inside
 
 .text-copy
-  p
+  p, ul, ol
     font-family: var(--font-family-serif)
   h1, h2, h3, h4, h5, h6
     font-family: var(--font-family-sans)


### PR DESCRIPTION
## Summary

- `ul` and `ol` inside `.text-copy` now inherit `--font-family-serif`, matching `<p>` copy
- Font size was already matched (`1.3rem` applied to `p, ul, ol`); this fixes the typeface discrepancy only

Closes novaramedia/novaramedia-com#537

## Test plan

- [ ] Verify article body list items render in serif font matching paragraph copy
- [ ] Check no regression on non-article list contexts (nav, inline action lists, UI lists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)