### PR TITLE
Fix: Grid deprecation comments leaking into compiled CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Deprecation comments in `functions/grid-function-new.styl` used `//` line syntax, which (unlike the indentation-syntax modules) leaked into compiled CSS and broke consumers' CSS minifiers (`Unexpected '/'`). Converted to `/* … */` block comments. Documented the brace-syntax caveat in `CONVENTIONS.md`.
+
 ## [0.14.0] - 2026-06-29
 
 ### Added

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -37,6 +37,23 @@ Mark any deprecated class / mixin / variable with a single-line comment
   ...
 ```
 
+> ⚠️ **Brace-syntax files use `/* … */`, not `//`.** In indentation-syntax
+> `.styl` files (most of `modules/`), `//` line comments are stripped at
+> compile time. But in files written in CSS-like **brace/`;` syntax** — notably
+> `functions/grid-function-new.styl` — a `//` comment placed directly above an
+> emitted rule **leaks into the compiled CSS**, where the `/` then breaks
+> consumers' CSS minifiers (postcss-selector-parser: "Unexpected '/'"). In those
+> files write the deprecation as a block comment, which compiles to a CSS comment
+> the minifier strips, and keep the text ASCII (use `->`, not `→`):
+>
+> ```stylus
+> /* @deprecated since vX.Y.Z: .old-name -> use .new-name. Removed: vA.B.0 */
+> .new-name, .old-name { ... }
+> ```
+>
+> (This caused the 0.14.0 → 0.14.1 build-break fix.) Still greppable on
+> `@deprecated since`.
+
 ### Why this format
 
 It is **greppable**, which lets the upstream/version-bump workflow find work

--- a/functions/grid-function-new.styl
+++ b/functions/grid-function-new.styl
@@ -61,13 +61,13 @@ grid-maker($size = false, $cols = 24)
       padding-right: calc(var(--grid-gutter) / 4);
     }
 
-    // @deprecated since v0.14.0: .grid--nested → use .grid-row--nested. Removed: v0.15.0
+    /* @deprecated since v0.14.0: .grid--nested -> use .grid-row--nested. Removed: v0.15.0 */
     .grid-row--nested, .grid--nested {
       margin-left: calc(var(--grid-gutter) / 2 * -1);
       margin-right: calc(var(--grid-gutter) / 2 * -1);
     }
 
-    // @deprecated since v0.14.0: .grid--nested-tight → use .grid-row--nested-tight. Removed: v0.15.0
+    /* @deprecated since v0.14.0: .grid--nested-tight -> use .grid-row--nested-tight. Removed: v0.15.0 */
     .grid-row--nested-tight, .grid--nested-tight {
       margin-left: calc(var(--grid-gutter) / 4 * -1);
       margin-right: calc(var(--grid-gutter) / 4 * -1);


### PR DESCRIPTION
## Problem

`0.14.0` shipped a build-breaking bug. The two `// @deprecated` comments in `functions/grid-function-new.styl` use Stylus **brace/`;` syntax**, where `//` line comments are **not stripped** at compile time (the indentation-syntax modules strip them fine). They leak into the emitted CSS, and the `/` in the comment breaks consumers' CSS minifier:

```
Error: main.css from Css Minimizer plugin
Error: Unexpected '/'. Escaping special characters with \ may help.  (postcss-selector-parser)
```

The library has no compile step, so `npm test` (variables sync) didn't catch it; it surfaced on the first production build in the consuming theme.

## Fix

- Convert the two comments to `/* … */` block comments — these compile to a CSS comment the minifier strips cleanly. Verified: theme `npm run build` (prod, minified) now succeeds; `.grid-row--nested`/`.grid--nested` selectors present, no `@deprecated` text in output.
- ASCII arrow (`->`) to be safe.
- `CONVENTIONS.md`: documented the brace-syntax caveat (use `/* */` there, `//` only in indentation files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)