### PR TITLE
feat: Stylus compile test, CI workflow, fix // leak in grid @css block

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,25 @@
-name: Test
+name: Validate design tokens & Stylus build
 
+# Checks variables.json/.styl/.js stay in sync and that index.styl
+# compiles cleanly with no invalid CSS leaking into the output.
 on:
   push:
     branches: [main]
   pull_request:
 
 jobs:
-  test:
+  validate:
+    name: Validate variables & compile Stylus
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-      - run: npm ci
-      - run: npm test
+      - name: Install dependencies
+        run: npm ci
+      - name: Run validation suite
+        run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CI workflow (`npm test` runs on all PRs and pushes to `main`)
+- `validate:stylus` script — compiles `index.styl` with `grid-maker()` calls and asserts no `//` leaks into CSS output
+
+### Fixed
+
+- `//` comments inside `@css {}` block in `grid-function-new.styl` converted to `/* */` — `//` is invalid CSS and was breaking the downstream minifier
+
 ## [0.14.0] - 2026-06-29
 
 ### Added

--- a/functions/grid-function-new.styl
+++ b/functions/grid-function-new.styl
@@ -61,13 +61,13 @@ grid-maker($size = false, $cols = 24)
       padding-right: calc(var(--grid-gutter) / 4);
     }
 
-    /* @deprecated since v0.14.0: .grid--nested → use .grid-row--nested. Removed: v0.15.0 */
+    /* @deprecated since v0.14.0: .grid--nested -> use .grid-row--nested. Removed: v0.15.0 */
     .grid-row--nested, .grid--nested {
       margin-left: calc(var(--grid-gutter) / 2 * -1);
       margin-right: calc(var(--grid-gutter) / 2 * -1);
     }
 
-    /* @deprecated since v0.14.0: .grid--nested-tight → use .grid-row--nested-tight. Removed: v0.15.0 */
+    /* @deprecated since v0.14.0: .grid--nested-tight -> use .grid-row--nested-tight. Removed: v0.15.0 */
     .grid-row--nested-tight, .grid--nested-tight {
       margin-left: calc(var(--grid-gutter) / 4 * -1);
       margin-right: calc(var(--grid-gutter) / 4 * -1);

--- a/functions/grid-function-new.styl
+++ b/functions/grid-function-new.styl
@@ -61,13 +61,13 @@ grid-maker($size = false, $cols = 24)
       padding-right: calc(var(--grid-gutter) / 4);
     }
 
-    // @deprecated since v0.14.0: .grid--nested → use .grid-row--nested. Removed: v0.15.0
+    /* @deprecated since v0.14.0: .grid--nested → use .grid-row--nested. Removed: v0.15.0 */
     .grid-row--nested, .grid--nested {
       margin-left: calc(var(--grid-gutter) / 2 * -1);
       margin-right: calc(var(--grid-gutter) / 2 * -1);
     }
 
-    // @deprecated since v0.14.0: .grid--nested-tight → use .grid-row--nested-tight. Removed: v0.15.0
+    /* @deprecated since v0.14.0: .grid--nested-tight → use .grid-row--nested-tight. Removed: v0.15.0 */
     .grid-row--nested-tight, .grid--nested-tight {
       margin-left: calc(var(--grid-gutter) / 4 * -1);
       margin-right: calc(var(--grid-gutter) / 4 * -1);

--- a/modules/ui.styl
+++ b/modules/ui.styl
@@ -373,7 +373,7 @@ hr
 // Rounded Elements
 // -------------
 
-// @deprecated since v0.14.0 → use .ui-rounded-box (CSS-identical at default). Removed: v0.15.0
+// @deprecated since v0.14.0 -> use .ui-rounded-box (CSS-identical at default). Removed: v0.15.0
 .ui-rounded-image
   --ui-border-radius: var(--corner-radius)
   border-radius: var(--ui-border-radius)
@@ -385,7 +385,7 @@ hr
   border-radius: var(--ui-border-radius)
   &--nested
     --ui-border-radius: var(--corner-radius-large)
-  // @deprecated since v0.14.0 → use --nested. Removed: v0.15.0
+  // @deprecated since v0.14.0 -> use --nested. Removed: v0.15.0
   &--large
     --ui-border-radius: var(--corner-radius-large)
   &--top
@@ -546,7 +546,7 @@ hr
     display: inline-block
     margin-right: 1rem
 
-// @deprecated since v0.14.0 → use .ui-embed-container. Removed: v0.15.0 (Un-nested from .ui-inline-list, where it was previously scoped by accident.)
+// @deprecated since v0.14.0 -> use .ui-embed-container. Removed: v0.15.0 (Un-nested from .ui-inline-list, where it was previously scoped by accident.)
 .ui-responsive-video-container
   position: relative
   padding-bottom: 56.25%

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,16 @@
       "license": "ISC",
       "devDependencies": {
         "@release-it/keep-a-changelog": "^7.0.0",
-        "release-it": "^19.0.4"
+        "release-it": "^19.0.4",
+        "stylus": "^0.64.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
+      "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@inquirer/checkbox": {
       "version": "4.1.9",
@@ -329,6 +337,80 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@nodeutils/defaults-deep": {
@@ -668,6 +750,17 @@
         "url": "https://github.com/phun-ky/typeof?sponsor=1"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@release-it/keep-a-changelog": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@release-it/keep-a-changelog/-/keep-a-changelog-7.0.0.tgz",
@@ -778,6 +871,13 @@
         "retry": "0.13.1"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/basic-ftp": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
@@ -794,6 +894,16 @@
       "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -1119,6 +1229,13 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
@@ -1289,6 +1406,23 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
@@ -1367,6 +1501,28 @@
       "license": "MIT",
       "dependencies": {
         "git-up": "^8.1.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -1595,6 +1751,22 @@
         "node": "^18.17 || >=20.6.1"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
@@ -1768,6 +1940,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -2036,6 +2234,13 @@
         "node": ">= 14"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parse-path": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
@@ -2069,6 +2274,30 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2305,6 +2534,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -2451,6 +2690,52 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -2467,6 +2752,30 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
@@ -2478,6 +2787,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylus": {
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.64.0.tgz",
+      "integrity": "sha512-ZIdT8eUv8tegmqy1tTIdJv9We2DumkNZFdCF5mz/Kpq3OcTaxSuCAYZge6HKK2CmNC02G1eJig2RV7XTw5hQrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "~4.3.3",
+        "debug": "^4.3.2",
+        "glob": "^10.4.5",
+        "sax": "~1.4.1",
+        "source-map": "^0.7.3"
+      },
+      "bin": {
+        "stylus": "bin/stylus"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://opencollective.com/stylus"
+      }
+    },
+    "node_modules/stylus/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/tinyexec": {
@@ -2613,6 +2955,70 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "0.14.0",
   "description": "",
   "scripts": {
-    "test": "npm run validate:variables",
+    "test": "npm run validate:variables && npm run validate:stylus",
     "build:variables": "node scripts/build-variables.js",
     "validate:variables": "node scripts/validate-variables.js",
+    "validate:stylus": "node scripts/validate-stylus.js",
     "prebuild": "npm run build:variables",
     "build": "echo \"Variables built successfully\"",
     "prerelease": "npm run build:variables",
@@ -26,7 +27,8 @@
   },
   "homepage": "https://github.com/novaramedia/nm-stylus-library#readme",
   "devDependencies": {
+    "@release-it/keep-a-changelog": "^7.0.0",
     "release-it": "^19.0.4",
-    "@release-it/keep-a-changelog": "^7.0.0"
+    "stylus": "^0.64.0"
   }
 }

--- a/scripts/validate-stylus.js
+++ b/scripts/validate-stylus.js
@@ -34,7 +34,7 @@ stylus(src)
     const lines = css.split('\n');
     const leaks = lines
       .map((line, i) => ({ line: i + 1, text: line }))
-      .filter(({ text }) => /^\s*\/\//.test(text));
+      .filter(({ text }) => /(^|[^:])\/\//.test(text));
 
     if (leaks.length > 0) {
       console.error('Invalid // comments found in CSS output (use /* */ inside @css {} blocks):\n');

--- a/scripts/validate-stylus.js
+++ b/scripts/validate-stylus.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const stylus = require('stylus');
+
+const ROOT = path.join(__dirname, '..');
+const ENTRY = path.join(ROOT, 'index.styl');
+
+// Wrap entry with grid-maker calls so @css{} blocks are emitted and testable.
+// Consuming projects call these at each breakpoint; without them the grid
+// passthrough blocks are never rendered and // leaks go undetected.
+const src = [
+  `@import "${ENTRY}"`,
+  `grid-maker('xl')`,
+  `grid-maker('l')`,
+  `grid-maker('m')`,
+  `grid-maker('s')`,
+].join('\n');
+
+console.log('Compiling index.styl (with grid-maker calls)...\n');
+
+stylus(src)
+  .set('filename', ENTRY)
+  .set('paths', [ROOT])
+  .render((err, css) => {
+    if (err) {
+      console.error('Stylus compilation failed:\n');
+      console.error(err.message);
+      process.exit(1);
+    }
+
+    // Detect // comments leaked into CSS output (invalid CSS, breaks minifiers).
+    // These appear when // is used inside @css {} passthrough blocks.
+    const lines = css.split('\n');
+    const leaks = lines
+      .map((line, i) => ({ line: i + 1, text: line }))
+      .filter(({ text }) => /^\s*\/\//.test(text));
+
+    if (leaks.length > 0) {
+      console.error('Invalid // comments found in CSS output (use /* */ inside @css {} blocks):\n');
+      leaks.forEach(({ line, text }) => console.error(`  Line ${line}: ${text.trim()}`));
+      process.exit(1);
+    }
+
+    const kb = (css.length / 1024).toFixed(1);
+    console.log(`Compiled successfully (${kb} KB output, no // leaks)\n`);
+  });

--- a/scripts/validate-stylus.js
+++ b/scripts/validate-stylus.js
@@ -1,17 +1,16 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
 const path = require('path');
 const stylus = require('stylus');
 
 const ROOT = path.join(__dirname, '..');
-const ENTRY = path.join(ROOT, 'index.styl');
+const VIRTUAL_FILENAME = path.join(ROOT, '__validate__.styl');
 
 // Wrap entry with grid-maker calls so @css{} blocks are emitted and testable.
 // Consuming projects call these at each breakpoint; without them the grid
 // passthrough blocks are never rendered and // leaks go undetected.
 const src = [
-  `@import "${ENTRY}"`,
+  `@import "index.styl"`,
   `grid-maker('xl')`,
   `grid-maker('l')`,
   `grid-maker('m')`,
@@ -21,7 +20,7 @@ const src = [
 console.log('Compiling index.styl (with grid-maker calls)...\n');
 
 stylus(src)
-  .set('filename', ENTRY)
+  .set('filename', VIRTUAL_FILENAME)
   .set('paths', [ROOT])
   .render((err, css) => {
     if (err) {

--- a/utility/helpers.styl
+++ b/utility/helpers.styl
@@ -54,7 +54,7 @@
  * Responsive oembed
  */
 
-// @deprecated since v0.14.0 → use .ui-embed-container. Removed: v0.15.0
+// @deprecated since v0.14.0 -> use .ui-embed-container. Removed: v0.15.0
 .u-video-embed-container
   position: relative
   padding-bottom: 56.25%


### PR DESCRIPTION
## Summary

- Adds `scripts/validate-stylus.js` — compiles `index.styl`, calls `grid-maker()` at all 4 breakpoints to emit `@css {}` passthrough blocks, then asserts no `//` comments leaked into CSS output
- Adds `.github/workflows/test.yml` — runs `npm test` on push to `main` and all PRs
- Fixes `functions/grid-function-new.styl` — `//` comments inside `@css {}` blocks converted to `/* */`; `//` is not valid CSS and breaks downstream minifiers (was the production breakage in novaramedia-com)

## Why the old test missed this

The previous `validate-stylus.js` only compiled `index.styl` bare. `grid-maker()` is never called in the library itself — only by consuming projects at each breakpoint. Without calling it, the `@css {}` passthrough blocks are never rendered and `//` leaks are invisible.

## Test plan

- [x] `npm test` passes locally
- [x] Verified test fails on the unfixed code (8 leak lines caught, 2 per breakpoint × 4 breakpoints)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)